### PR TITLE
Use the package manager discovered from host's OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ fail2ban_services:
     # How should the ban be applied?
     # OPTIONAL: Defaults to the banaction listed above.
     banaction: iptables-multiport
-
-# The amount in seconds to cache apt-update.
-apt_cache_valid_time: 86400
 ```
 
 ## Example playbook

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,5 +22,3 @@ fail2ban_services:
     port: ssh
     filter: sshd
     logpath: /var/log/auth.log
-
-apt_cache_valid_time: 86400

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: ensure fail2ban is installed
-  apt: pkg=fail2ban state=latest update_cache=true cache_valid_time={{ apt_cache_valid_time }}
+  action: "{{ ansible_pkg_mgr }} name=fail2ban state=latest update_cache=yes"
   notify:
     - restart fail2ban
 


### PR DESCRIPTION
This project is using only the `apt` module to install the
fail2ban package. But, it would be great to support multiple OS
distributions that has different package managers.

We can use fact variable `ansible_pkg_mgr`, discovered during the setup
task for each host, to know the name of the Ansible's package manager
module. By example: `yum` or `apt`. With this, We are able to invoke
the right module for each host dynamically using the `action` command.

``` yml

- name: ensure fail2ban is installed¬
  action: "{{ ansible_pkg_mgr  }} name=fail2ban state=latest update_cache=yes"

```

Unfortunately, we can't continue to use the `apt_cache_valid_time`
and use only the common module properties: `name`, `state` and
`update_cache`.

Unfortunately, we can't use the [package module](https://docs.ansible.com/ansible/package_module.html) . Because it's only for Ansible >= 2.0.

I've the code on this PR with Amazon Linux and Ubuntu.
