### PR TITLE
change fail2ban_loglevel description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Below is a list of default values along with a description of what they do.
 
 ```
 # Which log level should it be output as?
-# 1 = ERROR, 2 = WARN, 3 = INFO, 4 = DEBUG
-fail2ban_loglevel: 3
+# ERROR, WARN, INFO, DEBUG
+fail2ban_loglevel: INFO
 
 # Where should log outputs be sent to?
 # SYSLOG, STDERR, STDOUT, file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-fail2ban_loglevel: 3
+fail2ban_loglevel: INFO
 fail2ban_logtarget: /var/log/fail2ban.log
 fail2ban_socket: /var/run/fail2ban/fail2ban.sock
 


### PR DESCRIPTION
fail2ban loglevel configuration parameter format has been changing in recent versions.

This pull request aims at using the most common format since version 0.9.0, which is string.

```
< 0.8.x : set log level using numeric only [ 0...3]
0.9.x : set log level using string only
> 0.10 : Set log level with both numeric and string (python log level)
```

https://github.com/fail2ban/fail2ban/issues/2008#issuecomment-355189381

Current version 0.10.0 supports both string and numeric, but the default version on some systems (e.g. ubuntu 16..04) e still 0.9.x therefore using the string format is more compatible.

Best regards,
José Lourenço